### PR TITLE
✨ added size_in_bytes property to file entries

### DIFF
--- a/functions/modules/web3_storage.js
+++ b/functions/modules/web3_storage.js
@@ -1,4 +1,5 @@
 const { Web3Storage, File } = require( 'web3.storage' )
+const { Buffer } = require( 'buffer' )
 const functions = require( 'firebase-functions' )
 const { web3 } = functions.config()
 const client = new Web3Storage( { token: web3.storage_api_token } )
@@ -13,6 +14,7 @@ exports.upload_file_to_web3 = async function( data, context ) {
 
         // Create blob out of string
         const file = new File( [ data_string ], name )
+        const size_in_bytes = Buffer.byteLength( data_string, 'uft8' )
         log( `file: `, file )
 
         // Store files to web3
@@ -38,7 +40,8 @@ exports.upload_file_to_web3 = async function( data, context ) {
             cid,
             name,
             ipfs_url: `https://${ cid }.ipfs.dweb.link`,
-            blockpaste_url: `https://blockspace.web.app/#/view/${ cid }`
+            blockpaste_url: `https://blockspace.web.app/#/view/${ cid }`,
+            size_in_bytes
         }
         log( `Readable format: `, readable_data )
 

--- a/src/hooks/pastes.js
+++ b/src/hooks/pastes.js
@@ -10,6 +10,7 @@ const get_text_content_of_url = url => fetch( url ).then( response => response.t
 * @returns {Object[]} paste[] - Structure of a Paste object as received from firestore
 * @property {String} paste.cid - The IPFS cid of this paste
 * @property {String} paste.name - The user-specified name of this paste
+* @property {String} paste.size_in_bytes - The size of the content of this paste in Bytes
 * @property {String} paste.ipfs_url - The web2 url where this paste can be loaded from
 * @property {String} paste.blockpaste_url - The local url of this paste
 * @property {Number} paste.updated - The timestamp at which this paste was last updated


### PR DESCRIPTION
I updated the existing two entries as well :)

File entries now conform to the structure:

```js
/**
* Single paste entry
* @param {string} cid - The cid of the paste (which is also our internal reference)
* @returns {Object} paste - Structure of a Paste object as received from firestore
* @property {String} paste.cid - The IPFS cid of this paste
* @property {String} paste.name - The user-specified name of this paste
* @property {String} paste.size_in_bytes - The size of the content of this paste in Bytes
* @property {String} paste.ipfs_url - The web2 url where this paste can be loaded from
* @property {String} paste.blockpaste_url - The local url of this paste
* @property {Number} paste.updated - The timestamp at which this paste was last updated
* @property {String} paste.updated_human - The human readable timestamp at which this paste was updated
* @property {Function} paste.get - Asynchronous function that gets the text content from the ipfs_url
*/
```